### PR TITLE
cmd/etgrep: update to v2 execution trace format

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,21 @@ apshuffle -write-links
 apshuffle -profile-sort=profile -with-trace | head -n 30
 ```
 
+### `etgrep`
+
+This tool gives a text-based peek into the data that make up Go's execution traces.
+Its basic output is similar to that of `go tool trace -d=1`, but it also allows printing events' associated call stacks, and filtering based on event type and call stack structure.
+
+It works with the v2 execution trace format, so supports execution traces from Go 1.22+.
+
+```
+etgrep -input=./pprof/trace -stacks | less
+```
+
+```
+etgrep -input=./pprof/trace -match='StateTransition "net/http...conn..serve" "ServeHTTP" "**" "sync...Mutex..Lock"' | less
+```
+
 ### `grstates`
 
 This tool creates a visualization of the state machines that a program's goroutines run through in an execution trace.
@@ -68,19 +83,6 @@ It works with the v2 execution trace format, so supports execution traces from G
 
 ```
 grstates -input=./pprof/trace -svg=/tmp/trace.svg
-```
-
-### `etgrep`
-
-This tool gives a text-based peek into the data that make up Go's execution traces.
-Its basic output is similar to that of `go tool trace -d`, but it also allows printing events' associated call stacks, and filtering based on event type and call stack structure.
-
-```
-etgrep -input=./pprof/trace -stacks | less
-```
-
-```
-etgrep -input=./pprof/trace -match='GoBlockSync "net/http...conn..serve" "ServeHTTP" "**" "sync...Mutex..Lock"' | less
 ```
 
 ### `regiongraph`

--- a/cmd/etgrep/etgrep.go
+++ b/cmd/etgrep/etgrep.go
@@ -4,79 +4,169 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"os"
+	"runtime"
+	"sort"
 	"strings"
 
-	"github.com/rhysh/go-tracing-toolbox/internal"
-	"github.com/rhysh/go-tracing-toolbox/internal/_vendor/trace"
+	"github.com/rhysh/go-tracing-toolbox/internal/flag2"
+	"github.com/rhysh/go-tracing-toolbox/internal/match2"
+	"golang.org/x/exp/trace"
 )
 
 func main() {
 	input := flag.String("input", "", "Path to execution trace file")
 	showStacks := flag.Bool("stacks", false, "Show full stack of matching events")
-	goroutine := flag.Uint64("goroutine", 0, "Filter to events from a single goroutine")
+	goroutine := flag.Int64("goroutine", 0, "Filter to events from a single goroutine")
+	timestamp := flag.Int64("time", 0, "Filter to events with a specific timestamp")
+	sortBy := flag.String("sort", "time", `Sort by "time" or "goroutine"`)
 
-	var match internal.StackFlag
+	var match flag2.StackFlag
 	flag.Var(&match, "match", `
 Event and stack pattern to match. Try 'Any "**"' to match all events.
-Try 'GoBlockSync "net/http...conn..serve" "ServeHTTP" "**" "sync...Mutex..Lock"'
+Try 'StateTransition "net/http...conn..serve" "ServeHTTP" "**" "sync...Mutex..Lock"'
 to find stacks where an inbound HTTP request has to wait for a Mutex.`[1:])
 
 	flag.Parse()
 
-	data, err := func(name string) (*internal.Data, error) {
-		f, err := os.Open(name)
-		if err != nil {
-			return nil, err
-		}
-		defer f.Close()
-		result, err := trace.Parse(bufio.NewReader(f), "")
-		if err != nil {
-			return nil, err
-		}
-		data := internal.PrepareData(result.Events)
-		return data, nil
-	}(*input)
-	if err != nil {
-		log.Fatalf("Parse; err = %v", err)
+	cfg := &config{
+		sort:       *sortBy,
+		showStacks: *showStacks,
+		match:      &match,
+		filterGoID: trace.GoID(*goroutine),
+		filterTime: trace.Time(*timestamp),
 	}
 
-	checkMatch := match.Event != 0 || match.Specs != nil
+	f, err := os.Open(*input)
+	if err != nil {
+		log.Fatalf("Open: %v", err)
+	}
+	defer f.Close()
 
-	var prevG uint64
-	for _, g := range data.GoroutineList {
-		if *goroutine != 0 && *goroutine != g {
-			continue
+	reader, err := trace.NewReader(bufio.NewReader(f))
+	if err != nil {
+		log.Fatalf("trace.NewReader: %v", err)
+	}
+
+	var timeEvents []trace.Event
+
+	for {
+		ev, err := reader.ReadEvent()
+		if err == io.EOF {
+			break
 		}
-		evs := data.GoroutineEvents[g]
-		for _, ev := range evs {
-			if checkMatch && (!match.EventMatches(ev.Type) || !internal.HasStackRe(ev.Stk, match.Specs...)) {
-				continue
-			}
-			if prevG != 0 && prevG != ev.G {
-				fmt.Printf("\n")
-			}
-			prevG = ev.G
 
-			var others []string
-			if prev := data.Backlinks[ev]; prev != nil && prev.G != ev.G {
-				others = append(others, fmt.Sprintf("from %s", prev))
+		if cfg.sort == "time" {
+			str := cfg.printableString(ev)
+			if str != "" {
+				fmt.Printf("%s", str)
 			}
-			if next := ev.Link; next != nil {
-				others = append(others, fmt.Sprintf("to %s", next))
-			}
-			more := ""
-			if len(others) > 0 {
-				more = " (" + strings.Join(others, ", ") + ")"
-			}
-			fmt.Printf("%s%s\n", ev, more)
+		} else {
+			timeEvents = append(timeEvents, ev)
+		}
+	}
 
-			if *showStacks {
-				for _, frame := range ev.Stk {
-					fmt.Printf("  %x %s %s:%d\n", frame.PC, frame.Fn, frame.File, frame.Line)
+	// TODO: to/from event links
+
+	if *sortBy == "goroutine" {
+		goroutineEvents := make(map[trace.GoID][]trace.Event)
+		var goroutineList []trace.GoID
+		for _, ev := range timeEvents {
+			goid := eventGoroutine(ev)
+			goroutineEvents[goid] = append(goroutineEvents[goid], ev)
+		}
+		for goid := range goroutineEvents {
+			goroutineList = append(goroutineList, goid)
+		}
+		sort.Slice(goroutineList, func(i, j int) bool { return goroutineList[i] < goroutineList[j] })
+
+		var prevG trace.GoID
+		for _, goid := range goroutineList {
+			evs := goroutineEvents[goid]
+			for _, ev := range evs {
+				str := cfg.printableString(ev)
+				if str != "" {
+					if prevG != goid {
+						if prevG != 0 {
+							fmt.Printf("\n")
+						}
+						prevG = goid
+					}
+					fmt.Printf("%s", str)
 				}
 			}
 		}
 	}
+}
+
+type config struct {
+	sort       string
+	showStacks bool
+	match      *flag2.StackFlag
+	filterGoID trace.GoID
+	filterTime trace.Time
+}
+
+func (c *config) printableString(ev trace.Event) string {
+	if c.filterGoID != 0 && c.filterGoID != eventGoroutine(ev) {
+		return ""
+	}
+	if c.filterTime != 0 && c.filterTime != ev.Time() {
+		return ""
+	}
+	if c.match.Event != 0 || c.match.Specs != nil {
+		if !c.match.EventMatches(ev.Kind()) || !match2.HasStackRe(eventStack(ev), c.match.Specs...) {
+			return ""
+		}
+	}
+
+	str := new(strings.Builder)
+	fmt.Fprintf(str, "%s\n", eventString(ev))
+	if c.showStacks {
+		fmt.Printf("%s", stackString(eventStack(ev)))
+	}
+	return str.String()
+}
+
+func eventGoroutine(ev trace.Event) trace.GoID {
+	goid := ev.Goroutine()
+	if goid == trace.NoGoroutine {
+		if ev.Kind() == trace.EventStateTransition {
+			st := ev.StateTransition()
+			if st.Resource.Kind == trace.ResourceGoroutine {
+				goid = st.Resource.Goroutine()
+			}
+		}
+	}
+	return goid
+}
+
+func eventStack(ev trace.Event) []runtime.Frame {
+	var stack []runtime.Frame
+	ev.Stack().Frames(func(f trace.StackFrame) bool {
+		stack = append(stack, runtime.Frame{
+			Function: f.Func,
+			File:     f.File,
+			Line:     int(f.Line),
+			PC:       uintptr(f.PC),
+		})
+		return true
+	})
+	return stack
+}
+
+func eventString(ev trace.Event) string {
+	str := ev.String()
+	first, _, _ := strings.Cut(str, "\n")
+	return first
+}
+
+func stackString(stk []runtime.Frame) string {
+	str := new(strings.Builder)
+	for _, frame := range stk {
+		fmt.Fprintf(str, "  %x %s %s:%d\n", frame.PC, frame.Function, frame.File, frame.Line)
+	}
+	return str.String()
 }

--- a/internal/flag2/flag.go
+++ b/internal/flag2/flag.go
@@ -1,0 +1,90 @@
+package flag2
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/rhysh/go-tracing-toolbox/internal/match2"
+	"golang.org/x/exp/trace"
+)
+
+type StackFlag struct {
+	Event trace.EventKind // Use 0 ("EventBad") to match everything
+	Specs []string
+}
+
+func (sf *StackFlag) EventMatches(t trace.EventKind) bool {
+	return sf.Event == trace.EventBad || sf.Event == t
+}
+
+var _ flag.Value = (*StackFlag)(nil)
+
+func (sf *StackFlag) String() string {
+	if sf == nil {
+		return "<nil>"
+	}
+
+	var buf strings.Builder
+
+	name := ""
+	if sf.Event == trace.EventBad {
+		name = "Any"
+	} else {
+		name = sf.Event.String()
+	}
+	fmt.Fprintf(&buf, "%s", name)
+	for _, fn := range sf.Specs {
+		fmt.Fprintf(&buf, " %q", fn)
+	}
+	if len(sf.Specs) == 0 {
+		fmt.Fprintf(&buf, " **")
+	}
+	return buf.String()
+}
+
+func (sf *StackFlag) Set(v string) error {
+	sf.Event = trace.EventBad
+	sf.Specs = nil
+
+	parts := strings.SplitN(v, " ", 2)
+	for kind := trace.EventKind(1); kind != trace.EventBad; kind++ {
+		if kind.String() == trace.EventBad.String() {
+			break
+		}
+		if kind.String() == parts[0] {
+			sf.Event = kind
+			break
+		}
+	}
+	if sf.Event == trace.EventBad {
+		if parts[0] == "Any" {
+			// leave as 0 / EventBad
+		} else {
+			return fmt.Errorf("invalid trace event name %q", parts[0])
+		}
+	}
+
+	if len(parts) == 1 {
+		return nil
+	}
+	specs := strings.NewReader(parts[1])
+	for {
+		var s string
+		_, err := fmt.Fscanf(specs, "%q", &s)
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
+		sf.Specs = append(sf.Specs, s)
+	}
+
+	// Verify the stack-matching regular expressions (and memoize the compiled regexps)
+	err := match2.ValidateRe(sf.Specs...)
+	if err != nil {
+		return fmt.Errorf("invalid stack matcher flag: %w", err)
+	}
+	return nil
+}

--- a/internal/flag2/flag_test.go
+++ b/internal/flag2/flag_test.go
@@ -1,0 +1,54 @@
+package flag2_test
+
+import (
+	"testing"
+
+	"github.com/rhysh/go-tracing-toolbox/internal/flag2"
+)
+
+func TestFlag(t *testing.T) {
+	goodcase := func(v string) func(t *testing.T) {
+		return func(t *testing.T) {
+			var f flag2.StackFlag
+			err := f.Set(v)
+			if err != nil {
+				t.Fatalf("StackFlag.Set(%q); err = %v", v, err)
+			}
+		}
+	}
+
+	roundtripcase := func(v string) func(t *testing.T) {
+		return func(t *testing.T) {
+			var f flag2.StackFlag
+			err := f.Set(v)
+			if err != nil {
+				t.Fatalf("StackFlag.Set(%q); err = %v", v, err)
+			}
+			if s := f.String(); v != s {
+				t.Errorf("StackFlag.Set(%q).String() != %q", v, s)
+			}
+		}
+	}
+
+	badcase := func(v string) func(t *testing.T) {
+		return func(t *testing.T) {
+			var f flag2.StackFlag
+			err := f.Set(v)
+			if err == nil {
+				t.Fatalf("StackFlag.Set(%q); err = nil", v)
+			}
+		}
+	}
+
+	t.Run("", badcase(""))
+	t.Run("", badcase("Foo"))
+	t.Run("", badcase("None"))
+
+	t.Run("", goodcase("Metric"))
+	t.Run("", roundtripcase(`StateTransition "**"`))
+	t.Run("", roundtripcase(`StateTransition "^net/http...conn..serve$" "**"`))
+	t.Run("", roundtripcase(`Any "**" "^syscall.write$"`))
+
+	t.Run("", badcase(`StateTransition oops`))
+	t.Run("", badcase(`StateTransition "["`))
+}

--- a/internal/match2/match.go
+++ b/internal/match2/match.go
@@ -1,0 +1,200 @@
+package match2
+
+import (
+	"fmt"
+	"regexp"
+	"runtime"
+	"strings"
+	"sync"
+)
+
+// TODO: Since runtime.Frame.PC is a uintptr, we may have trouble when using
+// 32-bit machines to process execution traces that were created by 32-bit
+// machines. Add this to the list of reasons we may want our own types.
+
+func ValidateRe(specs ...string) error {
+	_, err := globalProgram.hasStackRe(nil, specs...)
+	return err
+}
+
+func HasStackRe(stk []runtime.Frame, specs ...string) bool {
+	match, err := globalProgram.hasStackRe(stk, specs...)
+	if err != nil {
+		panic(err)
+	}
+	return match != nil
+}
+
+func TrimVendor(fn string) string {
+	return globalProgram.trimVendor(fn)
+}
+
+var globalProgram program
+
+type program struct {
+	mu   sync.Mutex
+	re   map[string]regexpCompile
+	trim map[string]string
+}
+
+func (p *program) trimVendor(fn string) string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.trim == nil {
+		p.trim = make(map[string]string)
+	}
+	saved, ok := p.trim[fn]
+	if !ok {
+		saved = fn
+		if i := strings.LastIndex(saved, "/vendor/"); i >= 0 {
+			saved = saved[i+len("/vendor/"):]
+		}
+		saved = strings.TrimPrefix(saved, "vendor/")
+		p.trim[fn] = saved
+	}
+	return saved
+}
+
+type regexpCompile struct {
+	re  *regexp.Regexp
+	err error
+}
+
+func (p *program) compile(expr string) (*regexp.Regexp, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.re == nil {
+		p.re = make(map[string]regexpCompile)
+	}
+	saved, ok := p.re[expr]
+	if !ok {
+		saved.re, saved.err = regexp.Compile(expr)
+		p.re[expr] = saved
+	}
+	return saved.re, saved.err
+}
+
+func (p *program) mustCompile(expr string) *regexp.Regexp {
+	re, err := p.compile(expr)
+	if err != nil {
+		panic(fmt.Errorf("mustCompile: %w", err))
+	}
+	return re
+}
+
+func (p *program) hasStackRe(stk []runtime.Frame, specs ...string) ([]int, error) {
+	any := new(regexp.Regexp) // sentinel: zero or more stack frames
+
+	res := make([]*regexp.Regexp, 0, len(specs))
+	for _, spec := range specs {
+		switch spec {
+		case "**":
+			if len(res) == 0 || res[len(res)-1] != any {
+				// Collapse runs of ** into one
+				res = append(res, any)
+			}
+		default:
+			re, err := p.compile(spec)
+			if err != nil {
+				return nil, fmt.Errorf("could not compile regexp %q: %w", spec, err)
+			}
+			res = append(res, re)
+		}
+	}
+
+	if len(stk) == 0 {
+		if len(res) == 0 || (len(res) == 1 && res[0] == any) {
+			// A zero-length stack matches an empty list of specs, and matches a
+			// single **
+			return []int{}, nil
+		}
+	}
+
+	type path struct {
+		parent *path
+		frame  int
+		length int
+	}
+
+	// Run the NFA, starting immediately before the first matcher
+	prev := []*path{new(path)}
+	for i := len(stk) - 1; i >= 0; i-- {
+		// walk the stack starting at the root
+		frame := stk[i]
+		fn := p.trimVendor(frame.Function)
+		var next []*path
+		add := func(state *path) {
+			if len(next) == 0 || next[len(next)-1].length != state.length {
+				next = append(next, state)
+			}
+		}
+		for _, state := range prev {
+			if state.length >= len(res) {
+				continue
+			}
+
+			for j := state.length; j <= state.length+1 && j < len(res); j++ {
+				// When we match against **, we need to try this frame again
+				// with the next spec. Runs of ** have already been collapsed
+				// into a single **.
+				re := res[j]
+				if re == any {
+					add(state)
+					add(&path{parent: state, frame: i, length: state.length + 1})
+					continue
+				}
+				if re.MatchString(fn) {
+					v := &path{parent: state, frame: i, length: state.length + 1}
+					if j > state.length {
+						v = &path{parent: v, frame: i, length: v.length + 1}
+					}
+					add(v)
+				}
+				break
+			}
+		}
+		prev = next
+	}
+
+	// Check if the NFA reached the terminal state
+	var matchSets [][]int
+	for _, state := range prev {
+		if state.length == len(res) {
+			for node := state; node.parent != nil; node = node.parent {
+				re := res[node.length-1]
+				fn := stk[node.frame].Function
+
+				if re != any {
+					matches := re.FindStringSubmatchIndex(fn)
+					var newMatches []int
+					for i := 2; i < len(matches); i += 2 {
+						newMatches = append(newMatches, node.frame, matches[i], matches[i+1])
+					}
+					if len(newMatches) > 0 {
+						matchSets = append(matchSets, newMatches)
+					}
+				}
+			}
+
+			allMatches := []int{} // a non-nil slice indicates that the stack matches
+			for i := len(matchSets) - 1; i >= 0; i-- {
+				allMatches = append(allMatches, matchSets[i]...)
+			}
+			return allMatches, nil
+		}
+	}
+	return nil, nil
+}
+
+// FindStackSubmatchIndex searches stk for subexpressions described in specs. It
+// returns a slice of offsets in groups of three. The first element in each
+// group is number of leaf frames skipped before finding the subexpression. The
+// next two elements are the start and end byte offsets within that frame's
+// function name.
+func FindStackSubmatchIndex(stk []runtime.Frame, specs ...string) []int {
+	indexes, err := globalProgram.hasStackRe(stk, specs...)
+	if err != nil {
+		panic(err)
+	}
+	return indexes
+}

--- a/internal/match2/match_test.go
+++ b/internal/match2/match_test.go
@@ -1,0 +1,93 @@
+package match2_test
+
+import (
+	"reflect"
+	"runtime"
+	"testing"
+
+	"github.com/rhysh/go-tracing-toolbox/internal/match2"
+)
+
+func TestHasStackRe(t *testing.T) {
+	stack := []runtime.Frame{
+		{Function: "e"},
+		{Function: "x/vendor/d"},
+		{Function: "cee"},
+		{Function: "bee"},
+		{Function: "a"},
+	}
+
+	testcase := func(want bool, specs ...string) func(t *testing.T) {
+		return func(t *testing.T) {
+			have := match2.HasStackRe(stack, specs...)
+			if have != want {
+				t.Errorf("HasStackRe(%q); %t != %t", specs, have, want)
+			}
+		}
+	}
+
+	t.Run("", func(t *testing.T) {
+		match := match2.HasStackRe(nil, "**")
+		if !match {
+			t.Errorf("HasStackRe(nil, \"**\") should match")
+		}
+	})
+
+	t.Run("", func(t *testing.T) {
+		match := match2.HasStackRe(nil, "**", "f", "**")
+		if match {
+			t.Errorf("HasStackRe(nil, \"**\" \"f\" \"**\") should not match")
+		}
+	})
+
+	t.Run("", testcase(true, "**"))
+	t.Run("", testcase(true, `a`, "**"))
+	t.Run("", testcase(false, `bee`, "**"))
+	t.Run("", testcase(true, "**", `bee`, "**"))
+	t.Run("", testcase(true, "**", `e`))
+	t.Run("", testcase(true, "**", `e`, "**"))
+	t.Run("", testcase(true, "**", `a`, "**"))
+	t.Run("", testcase(true, `a`, "**", `bee`, "**"))
+	t.Run("", testcase(true, `a`, "**", "**", "**", `bee`, "**"))
+	t.Run("", testcase(true, `a`, `ee`, `ee`, "**"))
+	t.Run("", testcase(true, `a`, "**", `^d$`, "**"))
+	t.Run("", testcase(false, `a`, ".*", `^d$`, ".*"))
+	t.Run("", testcase(true, `a`, ".*", ".*", `^d$`, ".*"))
+	t.Run("", testcase(true, `a`, "**", "**", "**", "**", "**", "**", `^d$`, "**"))
+	t.Run("", testcase(false, "**", `x`, "**"))
+}
+
+func TestFindStackSubmatchIndex(t *testing.T) {
+	stack := []runtime.Frame{
+		{Function: "github.com/twitchtv/twirp/example.(*haberdasherServer).serveMakeHatProtobuf.func1"},
+		{Function: "github.com/twitchtv/twirp/example.(*haberdasherServer).serveMakeHatProtobuf.func2"},
+		{Function: "github.com/twitchtv/twirp/example.(*haberdasherServer).serveMakeHatProtobuf"},
+		{Function: "github.com/twitchtv/twirp/example.(*haberdasherServer).serveMakeHat"},
+		{Function: "github.com/twitchtv/twirp/example.(*haberdasherServer).ServeHTTP"},
+		{Function: "net/http.HandlerFunc.ServeHTTP"},
+		{Function: "net/http.serverHandler.ServeHTTP"},
+		{Function: "net/http.(*conn).serve"},
+	}
+
+	testcase := func(want []int, specs ...string) func(t *testing.T) {
+		return func(t *testing.T) {
+			have := match2.FindStackSubmatchIndex(stack, specs...)
+			if !reflect.DeepEqual(have, want) {
+				t.Errorf("FindStackSubmatchIndex(%q); %d != %d", specs, have, want)
+			}
+		}
+	}
+
+	t.Run("", testcase([]int{ // "github.com/twitchtv/twirp/example.(*haberdasherServer).serveMakeHat"
+		3, 0, 33, // "github.com/twitchtv/twirp/example"
+		3, 36, 47, // "haberdasher"
+		3, 60, 67, // "MakeHat"
+	}, `**`, `\.ServeHTTP$`, `^(.*)\.\(\*([^\)]*)Server\)\.serve([^\./]*)$`, `**`))
+
+	// The order of the triplets matches the order they appear in the specs
+	t.Run("", testcase([]int{ // "github.com/twitchtv/twirp/example.(*haberdasherServer).serveMakeHatProtobuf"
+		5, 0, 20, // "net/http.HandlerFunc"
+		2, 60, 67, // "MakeHat"
+	}, `**`, `^(.*)\.ServeHTTP$`, `\.ServeHTTP$`, `\.serve`, `\.serve([^\./]*)Protobuf$`, `**`))
+
+}


### PR DESCRIPTION
No support for to/from links at the moment. Use "time" as the default sort key, which in turn allows printing the trace as we process it rather than buffering all of the data in memory.

Allow setting "-sort=goroutine" to get the old behavior of sorting by goroutine ID, with a blank line to show when we're starting to display the next goroutine.

Add a "-time" flag to show events from a particular timestamp, perhaps to get more detail (such as the stack) about an event of interest.

Plus, make stack matchers work with the v2 trace API to enable all that.

Fixes #4

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
