### PR TITLE
cmd/grstates: decouple graph generation from display

### DIFF
--- a/cmd/grstates/dot.go
+++ b/cmd/grstates/dot.go
@@ -1,15 +1,10 @@
 package main
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"io"
-	"math"
 	"sort"
 	"strings"
-
-	"golang.org/x/exp/trace"
 )
 
 func leftEscape(str string) string {
@@ -20,71 +15,13 @@ func leftEscape(str string) string {
 	return `"` + strings.Join(parts, "\\l") + `"`
 }
 
-func hash(str string) string {
-	h := sha256.Sum256([]byte(str))
-	return "h" + hex.EncodeToString(h[:])
-}
-
-func writeDot(w io.Writer, goroutines map[trace.GoID]*behaviors, why *examples) error {
+func (g *vizGraph) writeDot(w io.Writer) error {
 	var err error
 	fprintf := func(format string, a ...any) {
 		if err != nil {
 			return
 		}
 		_, err = fmt.Fprintf(w, format, a...)
-	}
-
-	stackSet := newStackSet()
-
-	formatShort := func(state stackState) string {
-		return fmt.Sprintf("%s\n%s", state.state, stackSet.formatShort(state.stack))
-	}
-
-	var goids []trace.GoID
-	for goid, _ := range goroutines {
-		goids = append(goids, goid)
-	}
-	sort.Slice(goids, func(i, j int) bool { return goids[i] < goids[j] })
-
-	whyStrings := make(map[string]string)
-	whyState := func(ss stackState) {
-		name := formatShort(ss)
-		reason, _, _ := strings.Cut(why.stackState[ss].String(), "\n")
-		whyStrings[name] = reason
-	}
-	whyEdge := func(e edge) {
-		name := fmt.Sprintf("%s -> %s", hash(formatShort(e.from)), hash(formatShort(e.to)))
-		reason, _, _ := strings.Cut(why.edgeTo[e].String(), "\n")
-		whyStrings[name] = reason
-	}
-
-	allStates := make(map[stackState]int)
-	initStates := make(map[stackState]int)
-	finalStates := make(map[stackState]int)
-	statePairs := make(map[[2]stackState]int)
-	for _, goid := range goids {
-		b := goroutines[goid]
-
-		for edge, count := range b.edges {
-			if edge.from.stack == trace.NoStack {
-				continue
-			}
-			if edge.from.state == trace.GoNotExist {
-				initStates[edge.to]++
-				continue
-			}
-			if edge.to.state == trace.GoNotExist {
-				finalStates[edge.from]++
-				continue
-			}
-			allStates[edge.to]++
-			allStates[edge.from]++
-			statePairs[[2]stackState{edge.from, edge.to}] += count
-
-			whyState(edge.to)
-			whyState(edge.from)
-			whyEdge(edge)
-		}
 	}
 
 	var (
@@ -96,76 +33,24 @@ func writeDot(w io.Writer, goroutines map[trace.GoID]*behaviors, why *examples) 
 	fprintf("digraph %s {\n", chartName)
 	fprintf("\tsize=%q;\n", fmt.Sprintf("%d,%d", chartWidth, chartHeight))
 
-	initNodes := make(map[string]int)
-	otherNodes := make(map[string]int)
-	finalNodes := make(map[string]int)
-	edges := make(map[[2]string]int)
+	var nodeIDs []vizID
+	for id := range g.nodes {
+		nodeIDs = append(nodeIDs, id)
+	}
+	sort.Slice(nodeIDs, func(i, j int) bool { return g.nodePriority[nodeIDs[i]] < g.nodePriority[nodeIDs[j]] })
 
-	fprintf("\t/* goroutine init stacks */\n")
-	for state, count := range initStates {
-		str := formatShort(state)
-		initNodes[str] += count
-	}
-	var initKeys []string
-	for str := range initNodes {
-		initKeys = append(initKeys, str)
-	}
-	sort.Slice(initKeys, func(i, j int) bool {
-		ki, kj := initKeys[i], initKeys[j]
-		ni, nj := initNodes[ki], initNodes[kj]
-		if ni != nj {
-			// More common cases sort higher
-			return ni > nj
+	for _, id := range nodeIDs {
+		node := g.nodes[id]
+		var attrs []string
+		for _, key := range []string{"shape", "label", "tooltip", "comment"} {
+			attrs = append(attrs, fmt.Sprintf("%s=%s", key, node.attrs[key]))
 		}
-		return ki < kj
-	})
-	for _, key := range initKeys {
-		count := initNodes[key]
-		label := fmt.Sprintf("%s\n%s", "New goroutine", key)
-		fprintf("\t%s [label=%s]; /* seen %d times */\n", hash(key), leftEscape(label), count)
+		fprintf("\t%s [%s];\n", id.Hash(), strings.Join(attrs, ","))
 	}
 
-	fprintf("\t/* other known stacks */\n")
-	for state, count := range allStates {
-		if _, ok := initStates[state]; ok {
-			continue
-		}
-		str := formatShort(state)
-		otherNodes[str] += count
-	}
-	var otherKeys []string
-	for str := range otherNodes {
-		otherKeys = append(otherKeys, str)
-	}
-	sort.Slice(otherKeys, func(i, j int) bool {
-		ki, kj := otherKeys[i], otherKeys[j]
-		ni, nj := otherNodes[ki], otherNodes[kj]
-		if ni != nj {
-			// More common cases sort higher
-			return ni > nj
-		}
-		return ki < kj
-	})
-	for _, str := range otherKeys {
-		tooltip := fmt.Sprintf("example: %s", whyStrings[str])
-		fprintf("\t%s [shape=box,label=%s,tooltip=%q,comment=%q];\n", hash(str), leftEscape(str), tooltip, tooltip)
-	}
-
-	fprintf("\t/* edges */\n")
-	maxCount := 1
-	for pair, count := range statePairs {
-		edges[[2]string{formatShort(pair[0]), formatShort(pair[1])}] += count
-		if count > maxCount {
-			maxCount = count
-		}
-	}
-	penwidth := func(count int) float64 {
-		const maxWidth = 5
-		return (maxWidth-1)*(math.Log(float64(count))/math.Log(float64(maxCount))) + 1
-	}
-	var edgeKeys [][2]string
-	for strs := range edges {
-		edgeKeys = append(edgeKeys, strs)
+	var edgeKeys [][2]vizID
+	for ids := range g.edges {
+		edgeKeys = append(edgeKeys, ids)
 	}
 	sort.Slice(edgeKeys, func(i, j int) bool {
 		ki, kj := edgeKeys[i], edgeKeys[j]
@@ -174,42 +59,17 @@ func writeDot(w io.Writer, goroutines map[trace.GoID]*behaviors, why *examples) 
 		}
 		return ki[1] < kj[1]
 	})
-	for _, strs := range edgeKeys {
-		count := edges[strs]
-		name := fmt.Sprintf("%s -> %s", hash(strs[0]), hash(strs[1]))
-		tooltip := fmt.Sprintf("example: %s", whyStrings[name])
-		fprintf("\t%s [weight=%d,penwidth=%f,tooltip=%q,comment=%q];\n", name, count,
-			penwidth(count), tooltip, tooltip)
-	}
 
-	fprintf("\t/* end stacks */\n")
-	for state, count := range finalStates {
-		str := formatShort(state)
-		finalNodes[str] += count
-	}
-	var finalKeys []string
-	for str := range finalNodes {
-		finalKeys = append(finalKeys, str)
-	}
-	sort.Slice(finalKeys, func(i, j int) bool {
-		ki, kj := finalKeys[i], finalKeys[j]
-		ni, nj := finalNodes[ki], finalNodes[kj]
-		if ni != nj {
-			// More common cases sort higher
-			return ni > nj
+	for _, key := range edgeKeys {
+		edge := g.edges[key]
+		var attrs []string
+		for _, key := range []string{"weight", "penwidth", "tooltip", "comment"} {
+			attrs = append(attrs, fmt.Sprintf("%s=%s", key, edge.attrs[key]))
 		}
-		return ki < kj
-	})
-	for _, str := range finalKeys {
-		count := finalNodes[str]
-		from := hash(str)
-		to := "EXIT_" + from
-		fprintf("\t%s [label=%q];\n", to, "EXIT")
-		fprintf("\t%s -> %s [weight=%d,penwidth=%f];\n", from, to, count,
-			penwidth(count))
+		fprintf("\t%s -> %s [%s];\n", key[0].Hash(), key[1].Hash(), strings.Join(attrs, ","))
 	}
 
 	fprintf("}\n")
 
-	return nil
+	return err
 }

--- a/cmd/grstates/graph.go
+++ b/cmd/grstates/graph.go
@@ -1,0 +1,247 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+
+	"golang.org/x/exp/trace"
+)
+
+func buildGraph(goroutines map[trace.GoID]*behaviors, why *examples) *vizGraph {
+	graph := newVizGraph()
+
+	stackSet := newStackSet()
+
+	formatShort := func(state stackState) string {
+		return fmt.Sprintf("%s\n%s", state.state, stackSet.formatShort(state.stack))
+	}
+
+	var goids []trace.GoID
+	for goid, _ := range goroutines {
+		goids = append(goids, goid)
+	}
+	sort.Slice(goids, func(i, j int) bool { return goids[i] < goids[j] })
+
+	allStates := make(map[stackState]int)
+	initStates := make(map[stackState]int)
+	initWhy := make(map[stackState]trace.Event)
+	finalStates := make(map[stackState]int)
+	finalWhy := make(map[stackState]trace.Event)
+	edges := make(map[edge]int)
+	for _, goid := range goids {
+		b := goroutines[goid]
+
+		for e, count := range b.edges {
+			if e.from.stack == trace.NoStack {
+				continue
+			}
+			if e.from.state == trace.GoNotExist {
+				initStates[e.to]++
+				initWhy[e.to] = why.stackState[e.from]
+				continue
+			}
+			if e.to.state == trace.GoNotExist {
+				finalStates[e.from]++
+				finalWhy[e.from] = why.edgeTo[e]
+				continue
+			}
+			allStates[e.to]++
+			allStates[e.from]++
+
+			simpleEdge := edge{from: e.from, to: e.to} // ignore "via"
+			edges[simpleEdge] += count
+		}
+	}
+
+	var maxWeight int
+	for _, count := range edges {
+		if count > maxWeight {
+			maxWeight = count
+		}
+	}
+	penwidth := func(count int) float64 {
+		const maxWidth = 5
+		return (maxWidth-1)*(math.Log(float64(count))/math.Log(float64(maxWeight))) + 1
+	}
+
+	for edge, count := range edges {
+		reason, _, _ := strings.Cut(why.edgeTo[edge].String(), "\n")
+		tooltip := fmt.Sprintf("%q", "example: "+reason)
+
+		e := newVizEdge(vizID(formatShort(edge.from)), vizID(formatShort(edge.to)))
+		e.attrs["weight"] = fmt.Sprintf("%d", count)
+		e.attrs["penwidth"] = fmt.Sprintf("%f", penwidth(count))
+		e.attrs["tooltip"] = tooltip
+		e.attrs["comment"] = tooltip
+		graph.addEdge(e)
+	}
+
+	// goroutine launch states
+	initCount := make(map[vizID]int)
+	for ss, count := range initStates {
+		key := vizID(formatShort(ss))
+		label := fmt.Sprintf("%s\n%s", "New goroutine", formatShort(ss))
+
+		reason, _, _ := strings.Cut(initWhy[ss].String(), "\n")
+		tooltip := fmt.Sprintf("%q", reason)
+
+		node := newVizNode(key)
+		node.attrs["label"] = leftEscape(label)
+		node.attrs["tooltip"] = tooltip
+		node.attrs["comment"] = tooltip
+		node.attrs["shape"] = "ellipse"
+		graph.addNode(node)
+
+		initCount[key] = count
+	}
+	var initPrio []vizID
+	for key := range initCount {
+		initPrio = append(initPrio, key)
+	}
+	sort.Slice(initPrio, func(i, j int) bool {
+		ki, kj := initPrio[i], initPrio[j]
+		ni, nj := initCount[ki], initCount[kj]
+		if ni != nj {
+			// More common cases sort higher
+			return ni > nj
+		}
+		return ki < kj
+	})
+	for _, key := range initPrio {
+		graph.nodePriority[key] = len(graph.nodePriority) + 1
+	}
+
+	// goroutine non-initial states
+	allCount := make(map[vizID]int)
+	for ss, count := range allStates {
+		if _, ok := initStates[ss]; ok {
+			continue
+		}
+
+		key := vizID(formatShort(ss))
+		label := formatShort(ss)
+		reason, _, _ := strings.Cut(why.stackState[ss].String(), "\n")
+		tooltip := fmt.Sprintf("%q", "example: "+reason)
+
+		node := newVizNode(key)
+		node.attrs["label"] = leftEscape(label)
+		node.attrs["tooltip"] = tooltip
+		node.attrs["comment"] = tooltip
+		node.attrs["shape"] = "box"
+		graph.addNode(node)
+
+		allCount[key] = count
+	}
+	var allPrio []vizID
+	for key := range allCount {
+		allPrio = append(allPrio, key)
+	}
+	sort.Slice(allPrio, func(i, j int) bool {
+		ki, kj := allPrio[i], allPrio[j]
+		ni, nj := allCount[ki], allCount[kj]
+		if ni != nj {
+			// More common cases sort higher
+			return ni > nj
+		}
+		return ki < kj
+	})
+	for _, key := range allPrio {
+		graph.nodePriority[key] = len(graph.nodePriority) + 1
+	}
+
+	// goroutine final states
+	exitCount := make(map[vizID]int)
+	for ss, count := range finalStates {
+		fromKey := vizID(formatShort(ss))
+		exitKey := vizID("EXIT_" + formatShort(ss))
+		label := "EXIT"
+		reason, _, _ := strings.Cut(finalWhy[ss].String(), "\n")
+		tooltip := fmt.Sprintf("%q", "example: "+reason)
+
+		node := newVizNode(exitKey)
+		node.attrs["label"] = leftEscape(label)
+		node.attrs["tooltip"] = tooltip
+		node.attrs["comment"] = tooltip
+		node.attrs["shape"] = "ellipse"
+		graph.addNode(node)
+
+		e := newVizEdge(fromKey, exitKey)
+		e.attrs["weight"] = fmt.Sprintf("%d", count)
+		e.attrs["penwidth"] = fmt.Sprintf("%f", penwidth(count))
+		e.attrs["tooltip"] = tooltip
+		e.attrs["comment"] = tooltip
+		graph.addEdge(e)
+
+		exitCount[exitKey] = count
+	}
+	var exitPrio []vizID
+	for key := range exitCount {
+		exitPrio = append(exitPrio, key)
+	}
+	sort.Slice(exitPrio, func(i, j int) bool {
+		ki, kj := exitPrio[i], exitPrio[j]
+		ni, nj := allCount[ki], allCount[kj]
+		if ni != nj {
+			// More common cases sort higher
+			return ni > nj
+		}
+		return ki < kj
+	})
+	for _, key := range exitPrio {
+		graph.nodePriority[key] = len(graph.nodePriority) + 1
+	}
+
+	return graph
+}
+
+type vizID string
+
+func (id vizID) Hash() string {
+	h := sha256.Sum256([]byte(id))
+	return "h" + hex.EncodeToString(h[:])
+}
+
+type vizNode struct {
+	id    vizID
+	attrs map[string]string
+}
+
+type vizEdge struct {
+	from  vizID
+	to    vizID
+	attrs map[string]string
+}
+
+type vizGraph struct {
+	nodes        map[vizID]vizNode
+	edges        map[[2]vizID]vizEdge
+	nodePriority map[vizID]int
+}
+
+func newVizGraph() *vizGraph {
+	return &vizGraph{
+		nodes:        make(map[vizID]vizNode),
+		edges:        make(map[[2]vizID]vizEdge),
+		nodePriority: make(map[vizID]int),
+	}
+}
+
+func newVizNode(id vizID) vizNode {
+	return vizNode{id: id, attrs: make(map[string]string)}
+}
+
+func newVizEdge(from, to vizID) vizEdge {
+	return vizEdge{from: from, to: to, attrs: make(map[string]string)}
+}
+
+func (g *vizGraph) addNode(n vizNode) {
+	g.nodes[n.id] = n
+}
+
+func (g *vizGraph) addEdge(e vizEdge) {
+	g.edges[[2]vizID{e.from, e.to}] = e
+}

--- a/cmd/grstates/grstates.go
+++ b/cmd/grstates/grstates.go
@@ -91,7 +91,7 @@ func main() {
 
 	if *dotFile != "" {
 		dotBuf := new(bytes.Buffer)
-		err := writeDot(dotBuf, goroutines, why)
+		err := buildGraph(goroutines, why).writeDot(dotBuf)
 		if err != nil {
 			log.Fatalf("generate dot file: %v", err)
 		}
@@ -102,7 +102,7 @@ func main() {
 	}
 	if *svgFile != "" {
 		var dotBuf, svgBuf, errBuf bytes.Buffer
-		err := writeDot(&dotBuf, goroutines, why)
+		err := buildGraph(goroutines, why).writeDot(&dotBuf)
 		if err != nil {
 			log.Fatalf("generate dot file: %v", err)
 		}
@@ -246,6 +246,7 @@ func (b *behaviors) transitionTarget(ev goroutineStateTransition, stk trace.Stac
 	if from == trace.GoNotExist {
 		// Use the canonical version, stk.
 		b.prevState = stackState{stack: stk, state: from}
+		b.why.offerStackState(b.prevState, trace.Event(ev))
 	}
 
 	b.notice(ev, stk, to)


### PR DESCRIPTION
Prepare the graph's nodes and edges separately from writing them to the output buffer. There's still some coupling between that preparation and the DOT format (to specify attributes like weight and penwidth), but it's a step in a good direction.

This also gets us closer to displaying the sequence of states that a goroutine transitions through in between points where we can see its full stack.

And aside from https://go.dev/issue/68277, the output is deterministic.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
